### PR TITLE
Fix broken for loop that causes incorrect url/IP pairs

### DIFF
--- a/autodom.sh
+++ b/autodom.sh
@@ -1,4 +1,6 @@
-# Accepts $1 = domain, $2 = list of inscope IPs.
+# Automates subdomain enumeration and nslookups.
+# Usage: bash autodom.sh $domain $inscopeIPs
+# 
 #
 
 # Get the 2nd level domain as a string
@@ -19,17 +21,16 @@ touch $output/subdomains-resolving.txt
 touch $output/subdomains-inscope.txt
 touch $temp/resolved.txt
 
-## Perform the crtsh search
-#crtsh search -d $1 | tee ./$raws/crtsh_$name
+# Perform the crtsh search
+crtsh search -d $1 | tee ./$raws/crtsh_$name
 
 
-## Get the list of subdomains from the crtsh search
-#cat ./$raws/crtsh_$name | grep $name | choose 1 | sort -u | ansi2txt >> ./$output/subdomains-all.txt
+# Get the list of subdomains from the crtsh search
+cat ./$raws/crtsh_$name | grep $name | choose 1 | sort -u | ansi2txt >> ./$output/subdomains-all.txt
 
-####
-## OR
+### OR
 ## Use an existing list of subdomains
-cat $3 >> ./$output/subdomains-all.txt 
+# cat $3 >> ./$output/subdomains-all.txt 
 
 
 # Perform nslookups on all the subdomains excluding wildcards

--- a/autodom.sh
+++ b/autodom.sh
@@ -52,6 +52,7 @@ do
 	then
 		url=$f
 		count=2
+		pass
 	else
 		ip=$f
 		count=1

--- a/autodom.sh
+++ b/autodom.sh
@@ -19,12 +19,18 @@ touch $output/subdomains-resolving.txt
 touch $output/subdomains-inscope.txt
 touch $temp/resolved.txt
 
-# Perform the crtsh search
-crtsh search -d $1 | tee ./$raws/crtsh_$name
-# cp ./crtsh-temp ./$raws/crtsh_$name # For the sake of testing so I don't run too many crtsh searches.
+## Perform the crtsh search
+#crtsh search -d $1 | tee ./$raws/crtsh_$name
 
-# Get the list of subdomains from the crtsh search
-cat ./$raws/crtsh_$name | grep $name | choose 1 | sort -u | ansi2txt >> ./$output/subdomains-all.txt
+
+## Get the list of subdomains from the crtsh search
+#cat ./$raws/crtsh_$name | grep $name | choose 1 | sort -u | ansi2txt >> ./$output/subdomains-all.txt
+
+####
+## OR
+## Use an existing list of subdomains
+cat $3 >> ./$output/subdomains-all.txt 
+
 
 # Perform nslookups on all the subdomains excluding wildcards
 for f in `cat $output/subdomains-all.txt | grep -v '*'`; 
@@ -52,7 +58,7 @@ do
 	then
 		url=$f
 		count=2
-		pass
+		continue
 	else
 		ip=$f
 		count=1
@@ -73,6 +79,8 @@ do
 		echo $f >> $output/subdomains-inscope.txt
 	fi
 done < $output/subdomains-resolving.txt
+
+cat $output/subdomains-inscope.txt | sort -u | tee $output/subdomains-inscope.txt
 
 
 


### PR DESCRIPTION
The reformatting of subdomains in scope into a useful format is broken. The relevant for loop is configured to assign the previous IP to the current URL on each iteration, resulting in extra incorrect URL/IP pairings. 

This fixes the for loop and makes minor adjustments including:
- cleans up the comments
- adds a commented out option for running the script with an existing list of subdomains
- removes duplicates from the subdomains in scope output file